### PR TITLE
Bump to bot base v0.8.0

### DIFF
--- a/docker-compose-host-network.yml
+++ b/docker-compose-host-network.yml
@@ -1,7 +1,7 @@
 services:
   sc2_controller:
     network_mode: host
-    image: aiarena/arenaclient-sc2:v0.6.10
+    image: aiarena/arenaclient-sc2:v0.8.0
     environment:
       - "ACSC2_PORT=8083"
       - "ACSC2_PROXY_HOST=127.0.0.1"
@@ -15,7 +15,7 @@ services:
 
   bot_controller1:
     network_mode: host
-    image: aiarena/arenaclient-bot:v0.6.10
+    image: aiarena/arenaclient-bot:v0.8.0
     volumes:
       - "./bots:/bots"
       - "./logs/bot_controller1:/logs"
@@ -25,7 +25,7 @@ services:
 
   bot_controller2:
     network_mode: host
-    image: aiarena/arenaclient-bot:v0.6.10
+    image: aiarena/arenaclient-bot:v0.8.0
     volumes:
       - "./bots:/bots"
       - "./logs/bot_controller2:/logs"
@@ -35,7 +35,7 @@ services:
 
   proxy_controller:
     network_mode: host
-    image: aiarena/arenaclient-proxy:v0.6.10
+    image: aiarena/arenaclient-proxy:v0.8.0
     environment:
       - "ACPROXY_PORT=8080"
       - "ACPROXY_BOT_CONT_1_HOST=127.0.0.1"

--- a/docker-compose-multithread-example.yml
+++ b/docker-compose-multithread-example.yml
@@ -1,6 +1,6 @@
 services:
   sc2_controller:
-    image: aiarena/arenaclient-sc2:v0.6.10
+    image: aiarena/arenaclient-sc2:v0.8.0
     environment:
       - "ACSC2_PORT=8083"
       - "ACSC2_PROXY_HOST=proxy_controller"
@@ -13,7 +13,7 @@ services:
 #      - ~/StarCraftII/maps:/root/StarCraftII/maps                       # Relatively standard linux SC2 maps path
 
   bot_controller1:
-    image: aiarena/arenaclient-bot:v0.6.10
+    image: aiarena/arenaclient-bot:v0.8.0
     volumes:
       - "./bots:/bots"
       - "./runners/${COMPOSE_PROJECT_NAME}/logs/bot_controller1:/logs"
@@ -22,7 +22,7 @@ services:
       - "ACBOT_PROXY_HOST=proxy_controller"
 
   bot_controller2:
-    image: aiarena/arenaclient-bot:v0.6.10
+    image: aiarena/arenaclient-bot:v0.8.0
     volumes:
       - "./bots:/bots"
       - "./runners/${COMPOSE_PROJECT_NAME}/logs/bot_controller2:/logs"
@@ -31,7 +31,7 @@ services:
       - "ACBOT_PROXY_HOST=proxy_controller"
 
   proxy_controller:
-    image: aiarena/arenaclient-proxy:v0.6.10
+    image: aiarena/arenaclient-proxy:v0.8.0
     environment:
       - "ACPROXY_PORT=8080"
       - "ACPROXY_BOT_CONT_1_HOST=bot_controller1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sc2_controller:
-    image: aiarena/arenaclient-sc2:v0.6.10
+    image: aiarena/arenaclient-sc2:v0.8.0
     environment:
       - "ACSC2_PORT=8083"
       - "ACSC2_PROXY_HOST=proxy_controller"
@@ -13,7 +13,7 @@ services:
 #      - ~/StarCraftII/maps:/root/StarCraftII/maps                       # Relatively standard linux SC2 maps path
 
   bot_controller1:
-    image: aiarena/arenaclient-bot:v0.6.10
+    image: aiarena/arenaclient-bot:v0.8.0
     volumes:
       - "./bots:/bots"
       - "./logs/bot_controller1:/logs"
@@ -22,7 +22,7 @@ services:
       - "ACBOT_PROXY_HOST=proxy_controller"
 
   bot_controller2:
-    image: aiarena/arenaclient-bot:v0.6.10
+    image: aiarena/arenaclient-bot:v0.8.0
     volumes:
       - "./bots:/bots"
       - "./logs/bot_controller2:/logs"
@@ -31,7 +31,7 @@ services:
       - "ACBOT_PROXY_HOST=proxy_controller"
 
   proxy_controller:
-    image: aiarena/arenaclient-proxy:v0.6.10
+    image: aiarena/arenaclient-proxy:v0.8.0
     environment:
       - "ACPROXY_PORT=8080"
       - "ACPROXY_BOT_CONT_1_HOST=bot_controller1"


### PR DESCRIPTION
The actual change is only in [aiarena/arenaclient-bot/v0.8.0](https://hub.docker.com/layers/aiarena/arenaclient-bot/v0.8.0) but aligns all docker images to the same version.
Tested locally with the preconfigured test match.